### PR TITLE
Make the example work.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,15 +377,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pils-repl"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "pils",
- "rustyline",
-]
-
-[[package]]
 name = "pils-web"
 version = "0.1.0"
 dependencies = [
@@ -440,6 +431,15 @@ dependencies = [
  "getrandom",
  "redox_syscall",
  "thiserror",
+]
+
+[[package]]
+name = "repl"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "pils",
+ "rustyline",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 A super simple lisp interpreter inspired by buildyourownlisp.com, in Rust.
 
 # Example REPL
-Run `cargo run --bin repl` to get a pils Read-Eval-Print Loop.
+Run `cargo +nightly run --bin repl` to get a pils Read-Eval-Print Loop.

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pils-repl"
+name = "repl"
 authors = ["Rafael Bachmann <rafael.bachmann.93@gmail.com>"]
 version = "0.1.0"
 description = "Super simple lisp inspired by buildyourownlisp.com, in pure Rust."


### PR DESCRIPTION
```
❯ cargo run --bin repl
error: no bin target named `repl`.
Available bin targets:
    pils-repl
```

Change the name to "repl" in the Cargo.toml

```
❯ cargo run --bin repl
   Compiling pils v0.1.0 (/home/tim/rust/pils/pils)
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> pils/src/lib.rs:1:12
  |
1 | #![feature(lazy_cell)]
  |            ^^^^^^^^^
```
Add "+nightly" to the command in the README